### PR TITLE
feat: Integrate deal creation logic, update docs, and bump version to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MVTools v3.0.0
+# MVTools v3.1.0
 
 [![Mediavida](https://img.shields.io/badge/Target-Mediavida.com-orange)](https://www.mediavida.com)
 [![Repo](https://img.shields.io/badge/GitHub-Repo-blue)](https://github.com/Aleksnako/MVTools)
@@ -42,7 +42,7 @@ MVTools es una extensión de navegador diseñada para mejorar la experiencia de 
 * **Bundler:** Vite con `@samrum/vite-plugin-web-extension`
 * **Gestor de Paquetes:** pnpm
 * **UI:** Radix UI Primitives + shadcn/ui (implícito) + Tailwind CSS
-* **Estado/Datos:** TanStack Query (Server State) + TanStack Store (Client State?) + Zod (Validación)
+* **Estado/Datos:** TanStack Query (Async State) + TanStack Store (Global State) + Zod (Validación)
 * **Formularios:** TanStack Form
 * **APIs Extensión:** `webextension-polyfill`
 * **Iconos:** Lucide Icons

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mv-tools",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "displayName": "MVTools",
   "author": "josemariafs",
   "description": "Additional tools for www.mediavida.com",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,12 +10,14 @@ export const AI_MIN_POST_LENGTH = 350
 export const URLS = {
   MEDIAVIDA: 'https://www.mediavida.com',
   CHOLLOMETRO: 'https://www.chollometro.com',
+  CHOLLOMETRO_BACKEND: 'https://chollometro.digidip.net',
   GEMINI_CREATE_API_KEY: 'https://aistudio.google.com/app/apikey?hl=es-419'
 } as const
 
 export const ALLOWED_URLS = {
   MEDIAVIDA: `${URLS.MEDIAVIDA}/*`,
-  CHOLLOMETRO: `${URLS.CHOLLOMETRO}/*`
+  CHOLLOMETRO: `${URLS.CHOLLOMETRO}/*`,
+  CHOLLOMETRO_BACKEND: `${URLS.CHOLLOMETRO_BACKEND}/*`
 } as const
 
 export const ALL_ALLOWED_URLS = Object.values(ALLOWED_URLS)

--- a/src/entries/background/service-worker.ts
+++ b/src/entries/background/service-worker.ts
@@ -1,15 +1,16 @@
 import browser from 'webextension-polyfill'
 
-import { URLS } from '@/constants'
+import { ALLOWED_URLS, URLS } from '@/constants'
 import { getPerformedUpgradeTasks, setMigratedFromVersion, setPerformedUpgradeTask, UPGRADE_TASKS } from '@/services/upgrades'
 import { SCRIPT_FILES } from '@/types/content-script-assets'
 import {
+  type Deal,
+  type DealPayload,
   DefaultEventListenerPayloadSchema,
-  InjectDealScriptPayloadSchema,
   MESSAGE_TYPES,
   MigratedFromLocalStoragePayloadSchema
 } from '@/types/event-messages'
-import { initScriptFile, updatePopupBadge } from '@/utils/background'
+import { getActiveTab, initScriptFile, updatePopupBadge } from '@/utils/background'
 
 browser.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
   if (reason === 'update' && previousVersion) await setMigratedFromVersion(previousVersion)
@@ -25,29 +26,38 @@ browser.runtime.onMessage.addListener(async message => {
   const validMessage = DefaultEventListenerPayloadSchema.safeParse(message)
   if (!validMessage.success) {
     console.error('Invalid message received:', message)
-    return true
+    return
   }
 
   const { type } = validMessage.data
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Needed to explicitly check
   if (type === MESSAGE_TYPES.MIGRATED_FROM_LOCAL_STORAGE) {
     const { migrated } = MigratedFromLocalStoragePayloadSchema.parse(message)
     await setPerformedUpgradeTask(UPGRADE_TASKS.MIGRATED_FROM_LOCAL_STORAGE, migrated)
     updatePopupBadge({ pendingUpgrade: !migrated })
-    return true
   }
+})
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Needed to explicitly check
-  if (type === MESSAGE_TYPES.INJECT_DEAL_SCRIPT) {
-    const { deal } = InjectDealScriptPayloadSchema.parse(message)
-    const tab = await browser.tabs.create({ url: `${URLS.MEDIAVIDA}/foro/club-hucha/nuevo-hilo` })
+chrome.webRequest.onErrorOccurred.addListener(
+  async details => {
+    const url = new URL(details.url)
+    const finalLink = url.searchParams.get('url')
+    if (!finalLink) {
+      console.error('No link found in request:', details)
+      return
+    }
+
+    const activeTab = await getActiveTab()
+    const deal = await browser.tabs.sendMessage<DealPayload, Deal>(activeTab.id!, { type: MESSAGE_TYPES.DEAL })
+
+    const newDealThreadTab = await browser.tabs.create({ url: `${URLS.MEDIAVIDA}/foro/club-hucha/nuevo-hilo` })
     await initScriptFile({
-      tabId: tab.id!,
+      tabId: newDealThreadTab.id!,
       file: SCRIPT_FILES.FILL_NEW_DEAL_THREAD,
-      args: { deal },
+      args: { deal: { ...deal, link: finalLink } },
       debugMessage: 'Filling new deal thread'
     })
-  }
-
-  return true
-})
+  },
+  { urls: [ALLOWED_URLS.CHOLLOMETRO_BACKEND] }
+)

--- a/src/entries/contentScript/injected/fill-new-deal-thread.ts
+++ b/src/entries/contentScript/injected/fill-new-deal-thread.ts
@@ -1,11 +1,11 @@
 import { CSS_SELECTORS } from '@/constants'
-import type { InjectDealScriptPayload } from '@/types/event-messages'
+import type { Deal } from '@/types/event-messages'
 
 const { TITLE, DESCRIPTION, CATEGORY, OTHER_CATEGORY_OPTION } = CSS_SELECTORS.NEW_THREAD
 
 type ScriptWindow = Window &
   typeof globalThis & {
-    deal: InjectDealScriptPayload['deal']
+    deal: Deal
   }
 
 const { deal } = window as ScriptWindow

--- a/src/features/chollometro/deals/hooks/use-create-deal.ts
+++ b/src/features/chollometro/deals/hooks/use-create-deal.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import browser from 'webextension-polyfill'
+
+import { type Deal, DealPayloadSchema } from '@/types/event-messages'
+
+export const useCreateDeal = (deal: Deal) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const loadingTimeoutRef = useRef<NodeJS.Timeout>(null)
+
+  const createDeal = useCallback(() => {
+    setIsLoading(true)
+    /* eslint-disable-next-line @typescript-eslint/no-empty-function
+      -- This fetch will always fail, so we can safely ignore it.
+      Triggers the service worker function to get the actual deal link.
+     */
+    fetch(deal.link).catch(() => {})
+  }, [deal.link])
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/require-await -- Need to be async to return the data w/o using sendResponse
+    const listener = async (message: unknown) => {
+      const isValidMessage = DealPayloadSchema.safeParse(message)
+      if (!isValidMessage.success) return
+
+      setIsLoading(false)
+      return deal
+    }
+
+    browser.runtime.onMessage.addListener(listener)
+
+    return () => {
+      browser.runtime.onMessage.removeListener(listener)
+    }
+  }, [deal])
+
+  const clearLoadingTimeout = useCallback(() => {
+    if (!loadingTimeoutRef.current) return
+
+    clearTimeout(loadingTimeoutRef.current)
+    loadingTimeoutRef.current = null
+  }, [])
+
+  useEffect(() => {
+    if (!isLoading) {
+      clearLoadingTimeout()
+      return
+    }
+
+    loadingTimeoutRef.current = setTimeout(() => {
+      toast.error('Error al intentar poner la oferta en MV')
+      setIsLoading(false)
+      loadingTimeoutRef.current = null
+    }, 5000)
+
+    return clearLoadingTimeout
+  }, [isLoading])
+
+  return {
+    isLoading,
+    createDeal
+  }
+}

--- a/src/features/chollometro/deals/index.tsx
+++ b/src/features/chollometro/deals/index.tsx
@@ -2,36 +2,34 @@ import { useMemo } from 'react'
 import browser from 'webextension-polyfill'
 
 import { Button } from '@/components/ui/button'
+import { useCreateDeal } from '@/features/chollometro/deals/hooks/use-create-deal'
 import { Portal } from '@/features/shared/components/portal'
 import { getDealData } from '@/services/chollometro'
-import { type InjectDealScriptPayload, MESSAGE_TYPES } from '@/types/event-messages'
 import { cn } from '@/utils/tailwind'
 
 export const Deals = () => {
   const { buttonContainer, ...dealData } = useMemo(getDealData, [])
-
-  const handleClick = () => {
-    browser.runtime.sendMessage<InjectDealScriptPayload>({
-      type: MESSAGE_TYPES.INJECT_DEAL_SCRIPT,
-      deal: dealData
-    })
-  }
+  const { createDeal, isLoading } = useCreateDeal(dealData)
 
   return (
-    <Portal root={buttonContainer}>
+    <Portal
+      root={buttonContainer}
+      className='h-full'
+    >
       <Button
         variant='none'
         className={cn(
-          'text-foreground rounded-full bg-gray-700 px-7 h-9 text-start w-full text-lg font-bold leading-4 hover:bg-gray-500 mt-2',
-          'lg:h-[54px] lg:mt-0 lg:ml-3',
-          'md:h-[54px]'
+          'text-foreground rounded-full bg-gray-700 px-7 h-9 text-start w-full text-base font-bold hover:bg-gray-500 mt-2',
+          'lg:h-full lg:mt-0 lg:ml-3',
+          'md:h-[54px] md:text-lg'
         )}
-        onClick={handleClick}
+        onClick={createDeal}
+        disabled={isLoading}
       >
         <img
           src={browser.runtime.getURL('shared/icons/mvlogo.png')}
           alt='Media Vida Logo'
-          className='size-5'
+          className={cn('size-5', isLoading && 'animate-spin')}
         />
         Crear oferta
       </Button>

--- a/src/features/shared/components/portal.tsx
+++ b/src/features/shared/components/portal.tsx
@@ -1,18 +1,20 @@
-import { type PropsWithChildren, useEffect, useState } from 'react'
+import { type PropsWithChildren, useEffect, useLayoutEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { useShadowRoot } from '@/features/shared/hooks/use-shadow-root'
 import { useTheme } from '@/hooks/use-theme'
 import { renderContent } from '@/utils/dom'
+import { cn } from '@/utils/tailwind'
 
 interface Props extends PropsWithChildren {
   root?: HTMLElement
   where?: InsertPosition
   styles?: Partial<CSSStyleDeclaration>
+  className?: string
   title?: string
 }
 
-export const Portal = ({ children, root, where, styles, title }: Props) => {
+export const Portal = ({ children, root, where, styles, className, title }: Props) => {
   const { cssPaths } = useShadowRoot()
   const { theme } = useTheme()
   const [appRoot, setAppRoot] = useState<HTMLElement | null>(null)
@@ -22,8 +24,9 @@ export const Portal = ({ children, root, where, styles, title }: Props) => {
     renderContent({ cssPaths, render: setAppRoot, container: root, where, styles, title })
   }, [root])
 
-  useEffect(() => {
-    appRoot?.classList.add(theme)
+  useLayoutEffect(() => {
+    if (!appRoot) return
+    appRoot.className = cn(className, theme)
   }, [theme, appRoot])
 
   if (!appRoot) return null

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -65,11 +65,6 @@ const sharedManifest: SharedManifest = {
       js: ['src/entries/contentScript/sections/chollometro.tsx'],
       matches: [`${URLS.CHOLLOMETRO}/ofertas/*`],
       all_frames: true
-    },
-    {
-      js: ['src/entries/contentScript/sections/markers.tsx'],
-      matches: [`${URLS.MEDIAVIDA}/id/*/marcadores*`],
-      all_frames: true
     }
   ],
   icons: {
@@ -82,7 +77,7 @@ const sharedManifest: SharedManifest = {
     default_popup: 'src/entries/popup/index.html'
   },
   host_permissions: ALL_ALLOWED_URLS,
-  permissions: ['storage', 'scripting', 'activeTab'],
+  permissions: ['storage', 'scripting', 'activeTab', 'webRequest'],
   web_accessible_resources: [
     {
       resources: ['shared/*'],

--- a/src/services/media-vida.ts
+++ b/src/services/media-vida.ts
@@ -1,4 +1,4 @@
-import { CSS_SELECTORS, HTML_ATTRIBUTES } from '@/constants'
+import { CSS_SELECTORS, HTML_ATTRIBUTES, URLS } from '@/constants'
 import {
   type FavoritesElements,
   FROM_SECTIONS,

--- a/src/types/content-script-assets.ts
+++ b/src/types/content-script-assets.ts
@@ -2,7 +2,7 @@
 import type { AdditionalInput } from '@samrum/vite-plugin-web-extension'
 
 import type { GlobalConfig, StylesConfig } from '@/services/config'
-import type { InjectDealScriptPayload } from '@/types/event-messages'
+import type { Deal } from '@/types/event-messages'
 
 import { ALLOWED_URLS } from '../constants'
 
@@ -14,7 +14,7 @@ export interface ScriptArgObjects {
     stylesConfig: StylesConfig
   }
   FILL_NEW_DEAL_THREAD: {
-    deal: InjectDealScriptPayload['deal']
+    deal: Deal
   }
 }
 

--- a/src/types/event-messages.ts
+++ b/src/types/event-messages.ts
@@ -2,11 +2,11 @@ import { z } from 'zod'
 
 export const MESSAGE_TYPES = {
   MIGRATED_FROM_LOCAL_STORAGE: 'migratedFromLocalStorage',
-  INJECT_DEAL_SCRIPT: 'injectDealScript'
+  DEAL: 'deal'
 } as const
 
 export const DefaultEventListenerPayloadSchema = z.object({
-  type: z.enum([MESSAGE_TYPES.MIGRATED_FROM_LOCAL_STORAGE, MESSAGE_TYPES.INJECT_DEAL_SCRIPT])
+  type: z.enum([MESSAGE_TYPES.MIGRATED_FROM_LOCAL_STORAGE])
 })
 
 export const MigratedFromLocalStoragePayloadSchema = DefaultEventListenerPayloadSchema.extend({
@@ -16,16 +16,17 @@ export const MigratedFromLocalStoragePayloadSchema = DefaultEventListenerPayload
 
 export type MigratedFromLocalStoragePayload = z.infer<typeof MigratedFromLocalStoragePayloadSchema>
 
-export const InjectDealScriptPayloadSchema = z.object({
-  type: z.literal(MESSAGE_TYPES.INJECT_DEAL_SCRIPT),
-  deal: z.object({
-    title: z.string(),
-    price: z.string(),
-    link: z.string(),
-    description: z.string(),
-    dealImgUrl: z.string(),
-    voucher: z.string().optional()
-  })
+export interface Deal {
+  title: string
+  price: string
+  link: string
+  description: string
+  dealImgUrl: string
+  voucher?: string
+}
+
+export const DealPayloadSchema = z.object({
+  type: z.literal(MESSAGE_TYPES.DEAL)
 })
 
-export type InjectDealScriptPayload = z.infer<typeof InjectDealScriptPayloadSchema>
+export type DealPayload = z.infer<typeof DealPayloadSchema>

--- a/src/utils/background.ts
+++ b/src/utils/background.ts
@@ -37,3 +37,9 @@ export const updatePopupBadge = ({ pendingUpgrade }: { pendingUpgrade: boolean }
     browser.action.setBadgeBackgroundColor({ color: pendingUpgrade ? '#FF0000' : '#00FF00' })
   }
 }
+
+export const getActiveTab = async () => {
+  const [activeTab] = await browser.tabs.query({ active: true, lastFocusedWindow: true })
+  if (!activeTab) throw new Error('No active tab found')
+  return activeTab
+}


### PR DESCRIPTION
## Summary

This Pull Request updates the functionality for creating chollometro "deals" to get the final deal link, improves the related user experience, and updates the project documentation and version. It integrates a new `useCreateDeal` hook to handle the creation logic, refactors message types, and adds visual enhancements to the interface.

## Key Changes

### ✨ Features & Improvements (`feat`)

* **Deal Creation Logic:** Added the `useCreateDeal` hook to encapsulate and streamline the deal creation process.
* **Updated Permissions:** Included the `webRequest` permission in the manifest to retrieve the final deal destination URL after redirects.
* **Message Refactoring:** Updated deal-related message types and schemas, replacing `InjectDealScript` with a more appropriate `Deal` type/schema.
* **Frontend Enhancements:**
    * Implemented a loading state and spinner on the deal creation button to provide visual feedback to the user during the process.
    * Adjusted button styles to better match the host page's appearance.

### 🚀 Versioning (`chore`)

* Bumped the project version to `3.1.0`.

### 📚 Documentation (`docs`)

* Updated the `README.md` file to reflect the changes introduced in version `3.1.0`.
* Added clarifications regarding state management details in the documentation.

## Additional Context

* This PR also implicity fix some build problems with the previous versión 3.0.1

---